### PR TITLE
Update URLInfo.java

### DIFF
--- a/src/main/java/com/github/axet/wget/info/URLInfo.java
+++ b/src/main/java/com/github/axet/wget/info/URLInfo.java
@@ -154,7 +154,7 @@ public class URLInfo extends BrowserInfo {
                 }
 
                 HttpURLConnection meta(HttpURLConnection conn) throws IOException {
-                    String[] values = conn.getContentType().split(";");
+                    String[] values = (conn.getContentType()==null? "" : conn.getContentType()).split(";");
                     String contentType = values[0];
 
                     if (contentType.equals("text/html")) {


### PR DESCRIPTION
some special response doesn't have any 'contentType' header. so the `conn.getContentType()` will return `null`. To prevent from crash, i added some code.